### PR TITLE
feat(ci): auto-merge scala-steward patch & minor updates

### DIFF
--- a/.github/workflows/scala-steward-automerge.yml
+++ b/.github/workflows/scala-steward-automerge.yml
@@ -1,0 +1,62 @@
+name: Scala Steward auto-merge
+
+# Auto-merge the grouped patch/minor dependency PR opened by scala-steward once CI
+# passes. scala-steward opens PRs from a fork, so a `pull_request`-triggered job
+# would only get a read-only token. `workflow_run` runs in this repo's context with
+# a write token after CI finishes, which is what lets us merge.
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    # Only consider successful CI runs that came from a pull request.
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Merge grouped patch/minor PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          # Must match `pullRequests.grouping[].title` in .scala-steward.conf.
+          GROUP_TITLE: "chore(deps): update patch & minor dependencies"
+        run: |
+          set -euo pipefail
+
+          # workflow_run.pull_requests is empty for fork PRs, so resolve the PR
+          # from the CI run's head commit instead.
+          pr_number=$(gh api "repos/$REPO/commits/$HEAD_SHA/pulls" --jq '.[0].number // empty')
+          if [ -z "$pr_number" ]; then
+            echo "No PR found for commit $HEAD_SHA; nothing to do."
+            exit 0
+          fi
+
+          # Defense in depth: only the scala-steward grouped patch/minor PR may
+          # auto-merge. Anything else (major/individual PRs, other authors) is left
+          # for manual review.
+          IFS=$'\t' read -r author title < <(
+            gh pr view "$pr_number" --repo "$REPO" \
+              --json author,title \
+              --jq '[.author.login, .title] | @tsv'
+          )
+
+          if [ "$author" != "scala-steward" ]; then
+            echo "PR #$pr_number author is '$author', not scala-steward; skipping."
+            exit 0
+          fi
+          if [ "$title" != "$GROUP_TITLE" ]; then
+            echo "PR #$pr_number title is '$title', not the grouped patch/minor PR; leaving for manual review."
+            exit 0
+          fi
+
+          echo "Auto-merging patch/minor PR #$pr_number."
+          gh pr merge "$pr_number" --repo "$REPO" --squash

--- a/.github/workflows/scala-steward-automerge.yml
+++ b/.github/workflows/scala-steward-automerge.yml
@@ -1,9 +1,8 @@
 name: Scala Steward auto-merge
 
-# Auto-merge the grouped patch/minor dependency PR opened by scala-steward once CI
-# passes. scala-steward opens PRs from a fork, so a `pull_request`-triggered job
-# would only get a read-only token. `workflow_run` runs in this repo's context with
-# a write token after CI finishes, which is what lets us merge.
+# Auto-merge the grouped patch/minor PR from scala-steward once CI passes.
+# scala-steward opens PRs from a fork, where a `pull_request` job only gets a
+# read-only token; `workflow_run` runs in this repo's context with a write token.
 on:
   workflow_run:
     workflows: ["CI"]
@@ -17,7 +16,6 @@ jobs:
   auto-merge:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
-    # Only consider successful CI runs that came from a pull request.
     if: >
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success'

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,19 @@
+# Scala Steward configuration — https://github.com/scala-steward-org/scala-steward/blob/main/docs/repo-specific-configuration.md
+#
+# Conventional-commit messages. Because dependency PRs are squash-merged, the PR
+# title becomes the commit subject on `main`, keeping the history conventional.
+commits.message = "chore(deps): update ${artifactName} from ${currentVersion} to ${nextVersion}"
+
+# Collect every patch and minor update into a single PR with a fixed title, on one
+# stable branch (no ${hash} in `name`). Major, pre-release and build-metadata
+# updates fall outside this group and stay as individual PRs for manual review.
+#
+# The `title` below is matched verbatim by .github/workflows/scala-steward-automerge.yml
+# to decide what may auto-merge — keep the two in sync.
+pullRequests.grouping = [
+  {
+    name   = "patch-minor",
+    title  = "chore(deps): update patch & minor dependencies",
+    filter = [ { version = "patch" }, { version = "minor" } ]
+  }
+]

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,15 +1,9 @@
-# Scala Steward configuration — https://github.com/scala-steward-org/scala-steward/blob/main/docs/repo-specific-configuration.md
-#
-# Conventional-commit messages. Because dependency PRs are squash-merged, the PR
-# title becomes the commit subject on `main`, keeping the history conventional.
+# PRs are squash-merged, so this commit message becomes the subject on `main`.
 commits.message = "chore(deps): update ${artifactName} from ${currentVersion} to ${nextVersion}"
 
-# Collect every patch and minor update into a single PR with a fixed title, on one
-# stable branch (no ${hash} in `name`). Major, pre-release and build-metadata
-# updates fall outside this group and stay as individual PRs for manual review.
-#
-# The `title` below is matched verbatim by .github/workflows/scala-steward-automerge.yml
-# to decide what may auto-merge — keep the two in sync.
+# Patch + minor updates are grouped into one PR; major/pre-release/build-metadata
+# stay as individual PRs for manual review. The `title` is matched verbatim by
+# .github/workflows/scala-steward-automerge.yml — keep the two in sync.
 pullRequests.grouping = [
   {
     name   = "patch-minor",


### PR DESCRIPTION
## Summary
- Patch and minor dependency updates from Scala Steward now merge themselves once CI passes, so they no longer need to be merged by hand.
- Major updates still open a normal PR and wait for manual review.
- Scala Steward now groups all patch/minor bumps into a single PR with a conventional-commit title, instead of one PR per dependency.

## How it works
- `.scala-steward.conf` groups patch + minor updates into one PR and sets conventional-commit messages.
- A new workflow merges that grouped PR automatically after CI is green, verifying the PR is the grouped patch/minor one before merging.

## Test plan
- [ ] Confirm `.scala-steward.conf` is picked up on the next Scala Steward run.
- [ ] Verify the next grouped patch/minor PR is squash-merged automatically once CI passes.
- [ ] Verify a major-version PR is left open for manual review.

> Note: auto-merge only activates after this lands on `main`, since `workflow_run` workflows run from the default branch.

Implements #1436.