### PR TITLE
fix(build): restore CI by dropping obsolete Sonatype settings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,5 @@
 import Dependencies._
 import BuildHelper._
-import xerial.sbt.Sonatype.sonatypeCentralHost
-
-ThisBuild / sonatypeCredentialHost := sonatypeCentralHost
-ThisBuild / sonatypeLogLevel       := "debug"
 
 inThisBuild(
   List(


### PR DESCRIPTION
## Summary
- CI on `main` broke after the dependency update in #98 bumped sbt and the release plugin to newer versions.
- The build still referenced an old publishing configuration that those newer versions no longer provide, so the project failed to load and every CI job (tests + lint) errored before running.
- This removes the obsolete configuration. Publishing to Maven Central is now handled automatically by the newer tooling, so no replacement is needed.

## Test plan
- [x] Lint (`sbt check`) passes
- [x] Tests pass on Scala 2.13.18 (20/20)
- [x] Tests pass on Scala 3.3.1 (20/20)

Implements #1548.